### PR TITLE
UHF-6046: Update hook to fix the settings for header language links block

### DIFF
--- a/helfi_navigation.install
+++ b/helfi_navigation.install
@@ -109,6 +109,8 @@ function _helfi_navigation_get_block_configuration() : array {
       'region' => 'header_branding',
       'settings' => [
         'label' => 'External - Header language links',
+        'depth' => 2,
+        'expand_all_items' => TRUE,
       ],
     ],
     'external_header_top_navigation' => [
@@ -217,5 +219,24 @@ function helfi_navigation_update_9001() : void {
 
   foreach ($fields as $name => $field) {
     $manager->installFieldStorageDefinition($name, 'menu_link_content', 'helfi_navigation', $field);
+  }
+}
+
+/**
+ * Update Header language links block settings.
+ */
+function helfi_navigation_update_9002() : void {
+  /** @var \Drupal\Core\Extension\ThemeHandlerInterface $theme_handler */
+  $theme_handler = \Drupal::service('theme_handler');
+
+  if (str_starts_with($theme_handler->getDefault(), 'hdbt')) {
+    $config_factory = \Drupal::configFactory();
+    $block = $config_factory->getEditable('block.block.external_header_language_links');
+    $block_data = $block->getRawData();
+    if (!empty($block_data)) {
+      $block_data['settings']['depth'] = 2;
+      $block_data['settings']['expand_all_items'] = TRUE;
+      $block->setData($block_data)->save(TRUE);
+    }
   }
 }

--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -198,3 +198,19 @@ function helfi_navigation_page_attachments(array &$attachments) {
   catch (\Exception) {
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function helfi_navigation_preprocess_page(&$variables) {
+  $api_manager = Drupal::service('helfi_navigation.api_manager');
+  $lang_code = Drupal::languageManager()
+    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+    ->getId();
+  $response = $api_manager->get($lang_code, 'header-language-links');
+
+  // Show "header_language_links" button if menu has items.
+  if (!empty($response->data)) {
+    $variables['show_header_language_links_button'] = TRUE;
+  }
+}


### PR DESCRIPTION
## How to install
- `composer require drupal/helfi_navigation:dev-UHF-6046_block_settings`
- Run `make drush-updb drush-cr`

## How to test
- Check that the header language links block has correct settings