### PR TITLE
UHF-6960 Front page tasks

### DIFF
--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -182,10 +182,9 @@ function helfi_navigation_page_attachments(array &$attachments) {
   try {
     $links = [
       'api' => $apiManager->getUrl('api', $langcode, ['endpoint' => ApiManager::GLOBAL_MENU_ENDPOINT]),
-      // @todo Change this back once new Etusivu instance is live.
-      // 'canonical' => $apiManager->getUrl('base', $langcode),
-      'canonical' => 'https://www.hel.fi',
+      'canonical' => $apiManager->getUrl('base', $langcode),
     ];
+
     // @todo We need a better way to deal with local docker.so urls.
     foreach ($links as $type => $link) {
       $links[$type] = str_replace(['http://', ':8080'], ['https://', ''], $link);

--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -180,18 +180,11 @@ function helfi_navigation_page_attachments(array &$attachments) {
   $apiManager = Drupal::service('helfi_navigation.api_manager');
 
   try {
-    $links = [
-      'api' => $apiManager->getUrl('api', $langcode, ['endpoint' => ApiManager::GLOBAL_MENU_ENDPOINT]),
-      'canonical' => $apiManager->getUrl('base', $langcode),
-    ];
-
-    // @todo We need a better way to deal with local docker.so urls.
-    foreach ($links as $type => $link) {
-      $links[$type] = str_replace(['http://', ':8080'], ['https://', ''], $link);
-    }
-
     $attachments['#attached']['drupalSettings']['helfi_navigation'] = [
-      'links' => $links,
+      'links' => [
+        'api' => $apiManager->getUrl('api', $langcode, ['endpoint' => ApiManager::GLOBAL_MENU_ENDPOINT]),
+        'canonical' => $apiManager->getUrl('base', $langcode),
+      ],
     ];
   }
   catch (\Exception) {

--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -183,7 +183,7 @@ function helfi_navigation_page_attachments(array &$attachments) {
     $attachments['#attached']['drupalSettings']['helfi_navigation'] = [
       'links' => [
         'api' => $apiManager->getUrl('api', $langcode, ['endpoint' => ApiManager::GLOBAL_MENU_ENDPOINT]),
-        'canonical' => $apiManager->getUrl('base', $langcode),
+        'canonical' => $apiManager->getUrl('canonical', $langcode),
       ],
     ];
   }

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -176,7 +176,7 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
       // If the current menu link is not available, we're most likely browsing
       // the front page or first level of the menu tree.
       // Create back and current/parent links accordingly.
-      $url = $this->apiManager->getUrl('base',
+      $url = $this->apiManager->getUrl('canonical',
         $this->languageManager->getCurrentLanguage()->getId()
       );
 

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -180,9 +180,6 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
         $this->languageManager->getCurrentLanguage()->getId()
       );
 
-      // @todo We need a better way to deal with local docker.so urls.
-      $url = str_replace(['http://', ':8080'], ['https://', ''], $url);
-
       $menu_link_back = [
         'title' => $this->t('Front page'),
         'url' => Url::fromUri($url),

--- a/tests/src/FunctionalJavascript/JsSettingsTest.php
+++ b/tests/src/FunctionalJavascript/JsSettingsTest.php
@@ -58,8 +58,7 @@ class JsSettingsTest extends WebDriverTestBase {
 
       $settings = $this->getDrupalSettings();
       $this->assertEquals("https://helfi-etusivu.docker.so/$language/api/v1/global-menu", $settings['helfi_navigation']['links']['api']);
-      // @todo Fix once Etusivu instance is live.
-      $this->assertEquals("https://www.hel.fi", $settings['helfi_navigation']['links']['canonical']);
+      $this->assertEquals("https://helfi-etusivu.docker.so/$language", $settings['helfi_navigation']['links']['canonical']);
     }
   }
 


### PR DESCRIPTION
# [UHF-6960](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6960)

## What was done
* Changed API manager URL to point to Etusivu instance.
* Updated mobile menu fallback Etusivu -instance link.

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/helfi_navigation:dev-UHF-6960_front_page_tasks`
* Run `make drush-cr`

## How to test
* Check that the mobile menu and mobile menu fallback "Front page" links point to Etusivu -instance

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/376
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/447
