### PR TITLE
UHF-7396: Removed user.permissions cache context

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0']
+        php-versions: ['8.0', '8.1']
     container:
       image: ghcr.io/city-of-helsinki/drupal-php-docker:${{ matrix.php-versions }}-alpine
 
     services:
       db:
-        image: mariadb:10.5
+        image: mariadb:10.9
         env:
           MYSQL_USER: drupal
           MYSQL_PASSWORD: drupal

--- a/src/Menu/MenuTreeBuilder.php
+++ b/src/Menu/MenuTreeBuilder.php
@@ -52,6 +52,8 @@ final class MenuTreeBuilder {
    *   Language code.
    * @param object|null $rootElement
    *   The root element.
+   * @param \Drupal\Core\Menu\MenuTreeParameters|null $parameters
+   *   The menu tree parameters.
    *
    * @return array
    *   The resulting tree.
@@ -59,13 +61,18 @@ final class MenuTreeBuilder {
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
-  public function build(string $menuName, string $langcode, object $rootElement = NULL): array {
-    $tree = $this->menuTree->load(
-      $menuName,
-      (new MenuTreeParameters())
-        ->onlyEnabledLinks()
-    );
+  public function build(
+    string $menuName,
+    string $langcode,
+    object $rootElement = NULL,
+    MenuTreeParameters $parameters = NULL
+  ): array {
+    if (!$parameters) {
+      $parameters = new MenuTreeParameters();
+    }
+    $parameters->onlyEnabledLinks();
 
+    $tree = $this->menuTree->load($menuName, $parameters);
     $tree = $this->menuTree->transform($tree, [
       // Sync menu links accessible to anonymous users and sort them
       // the same way core does.

--- a/src/Plugin/Block/ExternalMenuBlockBase.php
+++ b/src/Plugin/Block/ExternalMenuBlockBase.php
@@ -64,7 +64,6 @@ abstract class ExternalMenuBlockBase extends MenuBlockBase implements ExternalMe
    */
   public function getCacheContexts() : array {
     return [
-      'user.permissions',
       'url.query_args',
       'url.path',
       'languages:language_content',

--- a/tests/src/Unit/ApiManagerTest.php
+++ b/tests/src/Unit/ApiManagerTest.php
@@ -23,6 +23,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -35,6 +36,7 @@ use Psr\Log\LoggerInterface;
 class ApiManagerTest extends UnitTestCase {
 
   use ApiTestTrait;
+  use ProphecyTrait;
 
   /**
    * The cache.
@@ -333,11 +335,13 @@ class ApiManagerTest extends UnitTestCase {
    */
   public function testMockFallbackException() : void {
     $this->expectException(FileNotExistsException::class);
+    $response = $this->prophesize(ResponseInterface::class);
+    $response->getStatusCode()->willReturn(403);
     $client = $this->createMockHttpClient([
       new ClientException(
         'Test',
         $this->prophesize(RequestInterface::class)->reveal(),
-        $this->prophesize(ResponseInterface::class)->reveal(),
+        $response->reveal(),
       ),
     ]);
     $sut = $this->getSut($client);


### PR DESCRIPTION
- `composer require drupal/helfi_navigation:dev-UHF-7396`
- `drush cr`
