### PR TITLE
UHF-7139: Remove footer top content configuration

### DIFF
--- a/helfi_navigation.install
+++ b/helfi_navigation.install
@@ -34,6 +34,7 @@ function helfi_navigation_install($is_syncing) : void {
   $old_menu_blocks = [
     'footertopblock',
     'footertopnavigation',
+    'footertopnavigationsecond',
     'footerbottomnavigation',
     'headertopnavigation',
     'mobile_navigation',


### PR DESCRIPTION
# UHF-7139 [UHF-7139](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7139)
Remove footer top content configuration and replace it with a real menu on instances that don't use global navigation.

## What was done
* Remove the footer top navigation - second menu block if one is set when enabling global navigation.

## How to install
* Check instructions from the [hdbt_admin PR](https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/173)

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* Check instructions from the [hdbt_admin PR](https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/173)

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/173
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/474
