### PR TITLE
UHF-7615: Added menu_block_current_language_tree_manipulator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^8.0",
-        "drupal/helfi_api_base": "*"
+        "drupal/helfi_api_base": "*",
+        "drupal/menu_block_current_language": "^1.5"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",

--- a/helfi_navigation.info.yml
+++ b/helfi_navigation.info.yml
@@ -5,5 +5,6 @@ core_version_requirement: ^9 || ^10
 dependencies:
   - drupal:block
   - drupal:helfi_api_base
+  - drupal:menu_block_current_language
   - drupal:menu_link_content
   - drupal:language

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -137,6 +137,7 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
     $manipulators = [
       ['callable' => 'menu.default_tree_manipulators:checkAccess'],
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
+      ['callable' => 'menu_block_current_language_tree_manipulator::filterLanguages'],
     ];
 
     // Get the grandparent link for the fallback menu.


### PR DESCRIPTION
UHF-7615: Added menu_block_current_language_tree_manipulator::filterLanguages to mobile menu fallback menu tree manipulator.