### PR TITLE
UHF-8292: Use content_translation_status field to determine if menu link should be published or not

### DIFF
--- a/helfi_navigation.install
+++ b/helfi_navigation.install
@@ -21,6 +21,7 @@ function helfi_navigation_install($is_syncing) : void {
   if ($is_syncing) {
     return;
   }
+  module_set_weight('helfi_navigation', 1);
 
   /** @var \Drupal\Core\Extension\ThemeHandlerInterface $theme_handler */
   $theme_handler = \Drupal::service('theme_handler');
@@ -57,6 +58,22 @@ function helfi_navigation_install($is_syncing) : void {
 
   update_user_rest_permissions();
 
+}
+
+/**
+ * Update user permissions.
+ */
+function update_user_rest_permissions(): void {
+  $config_factory = \Drupal::configFactory();
+
+  foreach (['user.role.anonymous', 'user.role.authenticated'] as $config) {
+    $role = $config_factory->getEditable($config);
+    $raw_data = $role->getRawData();
+    $raw_data['dependencies']['config'][] = 'rest.resource.helfi_global_mobile_menu';
+    $raw_data['dependencies']['module'][] = 'rest';
+    $raw_data['permissions'][] = 'restful get helfi_global_mobile_menu';
+    $role->setData($raw_data)->save(TRUE);
+  }
 }
 
 /**
@@ -280,17 +297,8 @@ function helfi_navigation_update_9003() : void {
 }
 
 /**
- * Update user permissions.
+ * Change module weight to make sure our hooks are run after 'menu_ui' module.
  */
-function update_user_rest_permissions(): void {
-  $config_factory = \Drupal::configFactory();
-
-  foreach (['user.role.anonymous', 'user.role.authenticated'] as $config) {
-    $role = $config_factory->getEditable($config);
-    $raw_data = $role->getRawData();
-    $raw_data['dependencies']['config'][] = 'rest.resource.helfi_global_mobile_menu';
-    $raw_data['dependencies']['module'][] = 'rest';
-    $raw_data['permissions'][] = 'restful get helfi_global_mobile_menu';
-    $role->setData($raw_data)->save(TRUE);
-  }
+function helfi_navigation_update_9004() : void {
+  module_set_weight('helfi_navigation', 1);
 }

--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -9,8 +9,10 @@ declare(strict_types = 1);
 
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\menu_link_content\MenuLinkContentInterface;
 use Drupal\system\MenuInterface;
 
@@ -153,7 +155,7 @@ function helfi_navigation_cron() : void {
 /**
  * Implements hook_page_attachments().
  */
-function helfi_navigation_page_attachments(array &$attachments) {
+function helfi_navigation_page_attachments(array &$attachments) : void {
   $langcode = Drupal::languageManager()
     ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
     ->getId();
@@ -170,5 +172,52 @@ function helfi_navigation_page_attachments(array &$attachments) {
     ];
   }
   catch (\Exception) {
+  }
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter() for \Drupal\node\NodeForm.
+ */
+function helfi_navigation_form_node_form_alter(
+  array &$form,
+  FormStateInterface $form_state
+) :void {
+  /** @var \Drupal\node\NodeInterface $node */
+  $node = $form_state->getFormObject()->getEntity();
+  $defaults = menu_ui_get_menu_link_defaults($node);
+
+  if ($defaults['entity_id']) {
+    $link = MenuLinkContent::load($defaults['entity_id']);
+
+    if ($link->hasTranslation($node->language()->getId())) {
+      $link = $link->getTranslation($node->language()->getId());
+    }
+    $defaults['content_translation_status'] = $link->get('content_translation_status')->value;
+  }
+
+  // Show menu link's 'published' field on node edit form.
+  $form['menu']['content_translation_status'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Published'),
+    '#default_value' => $defaults['content_translation_status'],
+  ];
+  $form['actions']['submit']['#submit'][] = 'helfi_navigation_form_node_form_submit';
+}
+
+/**
+ * A form submit callback for helfi_navigation_form_node_form_alter().
+ */
+function helfi_navigation_form_node_form_submit(array $form, FormStateInterface $formState) : void {
+  $values = $formState->getValue('menu');
+  $node = $formState->getFormObject()->getEntity();
+
+  if (!empty($values['entity_id'])) {
+    $link = MenuLinkContent::load($values['entity_id']);
+
+    if ($link->hasTranslation($node->language()->getId())) {
+      $link = $link->getTranslation($node->language()->getId());
+    }
+    $link->set('content_translation_status', $values['content_translation_status'])
+      ->save();
   }
 }

--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -199,6 +199,7 @@ function helfi_navigation_form_node_form_alter(
   $form['menu']['content_translation_status'] = [
     '#type' => 'checkbox',
     '#title' => t('Published'),
+    '#description' => t('A flag indicating whether this menu link translation is published'),
     '#default_value' => $defaults['content_translation_status'],
   ];
   $form['actions']['submit']['#submit'][] = 'helfi_navigation_form_node_form_submit';

--- a/src/Menu/MenuTreeBuilder.php
+++ b/src/Menu/MenuTreeBuilder.php
@@ -137,10 +137,9 @@ final class MenuTreeBuilder {
       /** @var \Drupal\menu_link_content\MenuLinkContentInterface $link */
       $link = $link->getTranslation($langcode);
 
-      $translationPublished = (bool) $link->get('content_translation_status')->value;
       // Only show accessible links (and published).
       if (
-        !$translationPublished ||
+        !$link->get('content_translation_status')->value ||
         ($element->access instanceof AccessResultInterface && !$element->access->isAllowed())
       ) {
         continue;

--- a/src/Menu/MenuTreeBuilder.php
+++ b/src/Menu/MenuTreeBuilder.php
@@ -137,10 +137,11 @@ final class MenuTreeBuilder {
       /** @var \Drupal\menu_link_content\MenuLinkContentInterface $link */
       $link = $link->getTranslation($langcode);
 
+      $translationPublished = (bool) $link->get('content_translation_status')->value;
       // Only show accessible links (and published).
       if (
-        ($element->access instanceof AccessResultInterface && !$element->access->isAllowed()) ||
-        !$link->isPublished()
+        !$translationPublished ||
+        ($element->access instanceof AccessResultInterface && !$element->access->isAllowed())
       ) {
         continue;
       }

--- a/src/Plugin/Block/ExternalMenuBlockBase.php
+++ b/src/Plugin/Block/ExternalMenuBlockBase.php
@@ -64,7 +64,6 @@ abstract class ExternalMenuBlockBase extends MenuBlockBase implements ExternalMe
    */
   public function getCacheContexts() : array {
     return [
-      'url.query_args',
       'url.path',
       'languages:language_content',
     ];

--- a/tests/src/Kernel/MenuTreeBuilderTest.php
+++ b/tests/src/Kernel/MenuTreeBuilderTest.php
@@ -89,7 +89,7 @@ class MenuTreeBuilderTest extends MenuTreeBuilderTestBase {
     $tree = $this->getMenuTree('en');
     $this->assertTree($tree['sub_tree'], TRUE);
 
-    // Translate one subtree item to make sure it's not visible in
+    // Translate a subtree item to make sure it's not visible in
     // finnish, because the parent is not translated.
     $linkEntities['0d8a1366-4fcd-4dbc-bb75-854dedf28a1b']->addTranslation('fi')
       ->save();
@@ -119,6 +119,14 @@ class MenuTreeBuilderTest extends MenuTreeBuilderTestBase {
     $this->assertEquals('fi-SV', $tree['sub_tree'][1]->attributes->lang);
     $tree = $this->getMenuTree('en');
     $this->assertEquals('en-US', $tree['sub_tree'][1]->attributes->lang);
+
+    // Unpublish a translated link and make sure it's not visible anymore.
+    $linkEntities['64a5a6d1-ffce-481b-b321-260d9cf66ad9']
+      ->getTranslation('fi')
+      ->set('content_translation_status', FALSE)
+      ->save();
+    $tree = $this->getMenuTree('fi');
+    $this->assertCount(1, $tree['sub_tree']);
   }
 
 }


### PR DESCRIPTION
## How to install
- `composer require drupal/helfi_navigation:dev-UHF-8292`
- `drush updb` 
- `drush cr`

## How to test

- Open a node edit form
- Make sure "Menu" section has `Published` field visible and you can change the menu link's published status by saving the node form
- Run `drush cron` and make sure unpublished menu link is no longer visible in Global navigation