### PR TITLE
UHF-8290: type_content to global menu and mobile fallback menu build

### DIFF
--- a/src/MainMenuManager.php
+++ b/src/MainMenuManager.php
@@ -96,7 +96,7 @@ class MainMenuManager {
    *   Menu tree.
    */
   public function build(string $langcode = NULL): array {
-    $langcode = $langcode ?: $this->languageManager->getCurrentLanguage()->getId();
+    $langcode = $langcode ?: $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
     $siteName = $this->getSiteName($langcode);
 
     $instanceUri = Url::fromRoute('<front>', options: [

--- a/src/MainMenuManager.php
+++ b/src/MainMenuManager.php
@@ -97,7 +97,7 @@ class MainMenuManager {
    *   Menu tree.
    */
   public function build(string $langcode = NULL): array {
-    $langcode = $langcode ?: $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
+    $langcode = $langcode ?: $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId();
     $siteName = $this->getSiteName($langcode);
 
     $instanceUri = Url::fromRoute('<front>', options: [

--- a/src/MainMenuManager.php
+++ b/src/MainMenuManager.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\helfi_navigation;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
 use Drupal\helfi_navigation\Menu\MenuTreeBuilder;
 use Drupal\language\ConfigurableLanguageManagerInterface;

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -177,7 +177,7 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
       // the front page or first level of the menu tree.
       // Create back and current/parent links accordingly.
       $url = $this->apiManager->getUrl('canonical',
-        $this->languageManager->getCurrentLanguage()->getId()
+        $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId()
       );
 
       $menu_link_back = [

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -179,7 +179,7 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
       // Create back and current/parent links accordingly.
       $url = $this->apiManager->getUrl(
         'canonical',
-        $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId()
+        $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId()
       );
 
       $menu_link_back = [

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -7,6 +7,7 @@ namespace Drupal\helfi_navigation\Plugin\Block;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Path\PathMatcherInterface;
 use Drupal\Core\Template\Attribute;

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -177,8 +177,9 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
       // If the current menu link is not available, we're most likely browsing
       // the front page or first level of the menu tree.
       // Create back and current/parent links accordingly.
-      $url = $this->apiManager->getUrl('canonical',
-        $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId()
+      $url = $this->apiManager->getUrl(
+        'canonical',
+        $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)->getId()
       );
 
       $menu_link_back = [


### PR DESCRIPTION
## Changed

MobileMenuFallbackBlock.php: Building content block for end user. Hence content language.

To test it, set up local global navigation as usually. Update menu item by saving it. run `drush cron`. mobile menu fallback block should render with correct items and correct language.

## No changes

MainMenuManager.php: Calling getCurrentLanguage when doing administrative operations. Therefore interface language. Also the language seemed to be always set so getCurrentLanguage was never called.




