### PR TITLE
UHF-8088: Fetch english external menus for alternative languages.

### DIFF
--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -160,11 +160,11 @@ function helfi_navigation_page_attachments(array &$attachments) : void {
     ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
     ->getId();
 
-  // Currently only Finnish, English and Swedish have standard support.
-  // Other languages should default to English external menus for now.
-  if (!in_array($langcode, ['fi', 'en', 'sv'])) {
-    $langcode = 'en';
-  }
+  /** @var \Drupal\helfi_api_base\Language\DefaultLanguageResolver $defaultLanguageResolver */
+  $defaultLanguageResolver = Drupal::service('helfi_api_base.default_language_resolver');
+
+  // Languages without standard support should use fallback language in menu.
+  $langcode = $defaultLanguageResolver->getCurrentOrFallbackLanguage();
 
   /** @var \Drupal\helfi_navigation\ApiManager $apiManager */
   $apiManager = Drupal::service('helfi_navigation.api_manager');

--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -160,6 +160,12 @@ function helfi_navigation_page_attachments(array &$attachments) : void {
     ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
     ->getId();
 
+  // Currently only Finnish, English and Swedish have standard support.
+  // Other languages should default to English external menus for now.
+  if (!in_array($langcode, ['fi', 'en', 'sv'])) {
+    $langcode = 'en';
+  }
+
   /** @var \Drupal\helfi_navigation\ApiManager $apiManager */
   $apiManager = Drupal::service('helfi_navigation.api_manager');
 

--- a/src/Plugin/Block/ExternalMenuBlockBase.php
+++ b/src/Plugin/Block/ExternalMenuBlockBase.php
@@ -93,10 +93,17 @@ abstract class ExternalMenuBlockBase extends MenuBlockBase implements ExternalMe
 
     $menuTree = NULL;
 
+    // Currently only Finnish, English and Swedish have standard support.
+    // Other languages should default to English external menus for now.
+    $langcode = $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
+    if (!in_array($langcode, ['fi', 'en', 'sv'])) {
+      $langcode = 'en';
+    }
+
     try {
       $menuId = $this->getDerivativeId();
       $response = $this->apiManager->get(
-        $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId(),
+        $langcode,
         $menuId,
       );
       $menuTree = $this->menuTreeBuilder

--- a/src/Plugin/Block/ExternalMenuBlockBase.php
+++ b/src/Plugin/Block/ExternalMenuBlockBase.php
@@ -13,7 +13,6 @@ use Drupal\helfi_navigation\ApiResponse;
 use Drupal\helfi_api_base\Language\DefaultLanguageResolver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-
 /**
  * Base class for creating external menu blocks.
  */

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -177,9 +177,16 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
       // If the current menu link is not available, we're most likely browsing
       // the front page or first level of the menu tree.
       // Create back and current/parent links accordingly.
+      // Currently only Finnish, English and Swedish have standard support.
+      // Other languages should default to English external menus for now.
+      $langcode = $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
+      if (!in_array($langcode, ['fi', 'en', 'sv'])) {
+        $langcode = 'en';
+      }
+
       $url = $this->apiManager->getUrl(
         'canonical',
-        $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId()
+        $langcode,
       );
 
       $menu_link_back = [

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -185,7 +185,7 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
       // If the current menu link is not available, we're most likely browsing
       // the front page or first level of the menu tree.
       // Create back and current/parent links accordingly.
-      // Languages without standard support should use fallback language in menu.
+      // Non-primary languages should use fallback language in menu.
       $langcode = $this->defaultLanguageResolver->getCurrentOrFallbackLanguage();
 
       $url = $this->apiManager->getUrl(

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -7,12 +7,12 @@ namespace Drupal\helfi_navigation\Plugin\Block;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Path\PathMatcherInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 use Drupal\helfi_navigation\ApiManager;
+use Drupal\helfi_api_base\Language\DefaultLanguageResolver;
 use Drupal\menu_link_content\MenuLinkContentInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -74,6 +74,13 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
   protected ApiManager $apiManager;
 
   /**
+   * Default language resolver.
+   *
+   * @var \Drupal\helfi_api_base\Language\DefaultLanguageResolver
+   */
+  protected DefaultLanguageResolver $defaultLanguageResolver;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(
@@ -89,6 +96,7 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
     $instance->pathMatcher = $container->get('path.matcher');
     $instance->languageManager = $container->get('language_manager');
     $instance->apiManager = $container->get('helfi_navigation.api_manager');
+    $instance->defaultLanguageResolver = $container->get('helfi_api_base.default_language_resolver');
     return $instance;
   }
 
@@ -177,12 +185,8 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
       // If the current menu link is not available, we're most likely browsing
       // the front page or first level of the menu tree.
       // Create back and current/parent links accordingly.
-      // Currently only Finnish, English and Swedish have standard support.
-      // Other languages should default to English external menus for now.
-      $langcode = $this->languageManager->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)->getId();
-      if (!in_array($langcode, ['fi', 'en', 'sv'])) {
-        $langcode = 'en';
-      }
+      // Languages without standard support should use fallback language in menu.
+      $langcode = $this->defaultLanguageResolver->getCurrentOrFallbackLanguage();
 
       $url = $this->apiManager->getUrl(
         'canonical',

--- a/tests/src/Functional/MenuBlockTest.php
+++ b/tests/src/Functional/MenuBlockTest.php
@@ -44,7 +44,7 @@ class MenuBlockTest extends BrowserTestBase {
   public function setUp() : void {
     parent::setUp();
 
-    foreach (['fi', 'sv'] as $langcode) {
+    foreach (['fi', 'sv', 'es'] as $langcode) {
       ConfigurableLanguage::createFromLangcode($langcode)->save();
     }
     $this->config('language.negotiation')

--- a/tests/src/Functional/MenuBlockTest.php
+++ b/tests/src/Functional/MenuBlockTest.php
@@ -48,7 +48,7 @@ class MenuBlockTest extends BrowserTestBase {
       ConfigurableLanguage::createFromLangcode($langcode)->save();
     }
     $this->config('language.negotiation')
-      ->set('url.prefixes', ['en' => 'en', 'fi' => 'fi', 'sv' => 'sv'])
+      ->set('url.prefixes', ['en' => 'en', 'fi' => 'fi', 'sv' => 'sv', 'es' => 'es'])
       ->save();
 
     NodeType::create([
@@ -71,6 +71,8 @@ class MenuBlockTest extends BrowserTestBase {
     // 1. Mega menu has only two levels of links.
     // 2. Block label is translated when a translation is provided.
     // 3. Link are translated.
+    // Also verify exception for non-primary languages:
+    // 4. On languages other than fi, sv, en the external menus use en versions.
     // These blocks and their content will be generated from fixtures/*.json
     // files.
     $expected = [
@@ -143,9 +145,32 @@ class MenuBlockTest extends BrowserTestBase {
           ],
         ],
       ],
+      'es' => [
+        'menus' => [
+          'External - Footer bottom navigation' => [
+            'Accessibility statement' => [],
+          ],
+          'External - Header language links' => [
+            'Selkokieli' => [],
+          ],
+          'External - Header top navigation' => [
+            'News' => [],
+          ],
+          'External - Mega menu' => [
+            'Urban environment and traffic' => [],
+            'Parking' => ['lang' => 'en-GB'],
+          ],
+          'City of Helsinki' => [
+            'Employment opportunities' => ['lang' => 'en-GB'],
+          ],
+          'Connect' => [
+            'Feedback' => [],
+          ],
+        ],
+      ],
     ];
 
-    foreach (['en', 'sv', 'fi'] as $language) {
+    foreach (['en', 'sv', 'fi', 'es'] as $language) {
       $this->drupalGet('/' . $language);
 
       ['menus' => $menus] = $expected[$language];

--- a/tests/src/Functional/MenuBlockTest.php
+++ b/tests/src/Functional/MenuBlockTest.php
@@ -48,8 +48,12 @@ class MenuBlockTest extends BrowserTestBase {
       ConfigurableLanguage::createFromLangcode($langcode)->save();
     }
     $this->config('language.negotiation')
-      ->set('url.prefixes', ['en' => 'en', 'fi' => 'fi', 'sv' => 'sv', 'es' => 'es'])
-      ->save();
+      ->set('url.prefixes', [
+        'en' => 'en',
+        'fi' => 'fi',
+        'sv' => 'sv',
+        'es' => 'es',
+      ])->save();
 
     NodeType::create([
       'type' => 'page',


### PR DESCRIPTION
# [UHF-8088](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8088)

## What was done
* Modifies External Menu Block Base to fetch English external menu content on languages other than Finnish, Swedish and English

## How to test
* Testing instructions in Etusivu instance PR: https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/351
* [ ] Check that code follows our standards
* [ ] Could this change have unforeseen effects on other instances and sites?

## Designers review
* [x] This PR does not need designers review

## Other PRs
* https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/351
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/646
* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/504
* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/103

[UHF-8088]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ