### PR TITLE
Prevent function call on null

### DIFF
--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -219,12 +219,15 @@ function helfi_navigation_form_node_form_alter(
 function helfi_navigation_form_node_form_submit(array $form, FormStateInterface $formState) : void {
   $values = $formState->getValue('menu');
   $node = $formState->getFormObject()->getEntity();
+  $langCode = $node->language()->getId();
 
   if (!empty($values['entity_id'])) {
-    $link = MenuLinkContent::load($values['entity_id']);
+    if (!$link = MenuLinkContent::load($values['entity_id'])) {
+      return;
+    }
 
-    if ($link->hasTranslation($node->language()->getId())) {
-      $link = $link->getTranslation($node->language()->getId());
+    if ($link->hasTranslation($langCode)) {
+      $link = $link->getTranslation($langCode);
     }
     $link->set('content_translation_status', $values['content_translation_status'])
       ->save();


### PR DESCRIPTION
Reproduce:
- Set up any site
- Look for any node in main navigation. Go and edit the node.
- Take the node off of the menu by disabling the `"Näytä sivu valikossa"` selection.
- Save the node
- Explosion should occur

Fix:
- No need to setup the site again, just run the commands below and `select different node to edit`.
`composer require drupal/helfi_navigation:dev-UHF-X_fix_error`
`make drush-cr`
- Follow the reproduction steps: edit the node etc....

Result:
- The node should have been saved successfully without whitescreen.