### PR TITLE
UHF-7955: Run mobile menu fallback through ::filterLanguages menu manipulator

### DIFF
--- a/src/Plugin/Block/MenuBlockBase.php
+++ b/src/Plugin/Block/MenuBlockBase.php
@@ -50,7 +50,7 @@ abstract class MenuBlockBase extends SystemMenuBlock {
   }
 
   /**
-   * {@inheritDoc}
+   * {@inheritdoc}
    */
   public function getMaxDepth(): int {
     $max_depth = $this->getConfiguration()['depth'];


### PR DESCRIPTION
## How to install
- `composer require drupal/helfi_navigation:dev-UHF-7955`
- `drush cr`

## How to test
- See https://helsinkisolutionoffice.atlassian.net/browse/UHF-7955