### PR TITLE
UHF-8700: Text changes in the menu publishing switch

### DIFF
--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -201,8 +201,8 @@ function helfi_navigation_form_node_form_alter(
   // Show menu link's 'published' field on node edit form.
   $form['menu']['content_translation_status'] = [
     '#type' => 'checkbox',
-    '#title' => t('Published'),
-    '#description' => t('A flag indicating whether this menu link translation is published'),
+    '#title' => t('Published in the main menu'),
+    '#description' => t('The selection will publish the page in hel.fi’s main and mobile menu. Set the selection as Published when you choose Provide a menu link from above. The page will not show up in the main menu or mobile menu without this selection.'),
     '#default_value' => $defaults['content_translation_status'],
   ];
   $form['actions']['submit']['#submit'][] = 'helfi_navigation_form_node_form_submit';

--- a/translations/fi.po
+++ b/translations/fi.po
@@ -1,5 +1,8 @@
 msgid ""
 msgstr ""
 
-msgid "A flag indicating whether this menu link translation is published"
-msgstr "Asetus määrittää onko tämän valikkolinkin käännös julkaistu"
+msgid "Published in the main menu"
+msgstr "Julkaistu päävalikossa"
+
+msgid "The selection will publish the page in hel.fi’s main and mobile menu. Set the selection as Published when you choose Provide a menu link from above. The page will not show up in the main menu or mobile menu without this selection."
+msgstr "Valinta julkaisee sivun koko hel.fin pää- ja mobiilivalikkoon. Aseta valinta julkaistu-tilaan, kun valitset yltä Näytä sivusto valikossa. Sivu ei näy päävalikossa eikä mobiilivalikossa ilman tätä valintaa."

--- a/translations/sv.po
+++ b/translations/sv.po
@@ -1,5 +1,8 @@
 msgid ""
 msgstr ""
 
-msgid "A flag indicating whether this menu link translation is published"
-msgstr "En flagga som indikerar om denna menylänköversättning är publicerad"
+msgid "Published in the main menu"
+msgstr "Publicerats i huvudmenyn"
+
+msgid "The selection will publish the page in hel.fi’s main and mobile menu. Set the selection as Published when you choose Provide a menu link from above. The page will not show up in the main menu or mobile menu without this selection."
+msgstr "Valet publicerar sidan i huvudmenyn och mobilmenyn på hela hel.fi. Välj publicerats när du väljer Ange en menylänk ovan. Sidan visas inte i huvudmenyn eller mobilmenyn utan detta val."


### PR DESCRIPTION
# [UHF-8700](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8700)
<!-- What problem does this solve? -->
The label and description in the switch for publishing a page on the main and mobile menu has been too ambiguous.

## What was done
<!-- Describe what was done -->

* Changed the label and description of the switch.
* Updated the translations.

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the Helgi Navigation
    * `composer require drupal/helfi_navigation:dev-UHF-8700_menu-publishing-text-changes`
* Run `make drush-cr drush-locale-update`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go add or edit any node (e.g. Standard page is good). Check the Menu settings -settings on the right side and the "Published in the main menu" switch. It should have the updated label and description.

[UHF-8700]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ