### PR TITLE
UHF-8738: prevent showing active trail on menuitem for link pointing to subdomain

### DIFF
--- a/fixtures/api-v1-global-menu-en.json
+++ b/fixtures/api-v1-global-menu-en.json
@@ -35,6 +35,22 @@
         "weight": 0,
         "sub_tree": [
           {
+            "url": "https://paatokset.hel.fi/en/urban-environment-and-traffic/cycling",
+            "id": "menu_link_content:df660188-d56f-4cb4-9539-32945792da18",
+            "name": "Decisions",
+            "parentId": "base:health_and_social_services",
+            "attributes": {},
+            "external": true,
+            "hasItems": false,
+            "expanded": false,
+            "parents": [
+              "menu_link_content:df660188-d56f-4cb4-9539-32945792da18",
+              "base:health_and_social_services"
+            ],
+            "weight": -49,
+            "sub_tree": []
+          },
+          {
             "url": "https://helfi-kymp.docker.so/en/urban-environment-and-traffic/parking",
             "id": "menu_link_content:7c9ddcc2-4d07-4785-8940-046b4cb85fb4",
             "name": "Parking",

--- a/src/ExternalMenuTreeBuilder.php
+++ b/src/ExternalMenuTreeBuilder.php
@@ -192,6 +192,13 @@ final class ExternalMenuTreeBuilder {
     $currentPath = parse_url($request->getUri(), PHP_URL_PATH);
     $linkPath = parse_url($item->url->getUri(), PHP_URL_PATH);
 
+    // Subdomain cannot be in active trail.
+    $host = parse_url($item->url->getUri(), PHP_URL_HOST);
+    $host = str_replace('www.', '', $host);
+    if (explode('.',$host)[0] != 'hel') {
+      return FALSE;
+    }
+
     // We don't care about the domain when comparing URLs because the
     // site might be served from multiple different domains.
     if ($linkPath === $currentPath) {

--- a/src/ExternalMenuTreeBuilder.php
+++ b/src/ExternalMenuTreeBuilder.php
@@ -183,7 +183,11 @@ final class ExternalMenuTreeBuilder {
    *   Returns true or false.
    */
   private function inActiveTrail(object $item): bool {
-    if ($item->url->isRouted() && $item->url->getRouteName() === '<nolink>') {
+    if (
+      $item->url->isRouted() &&
+      $item->url->getRouteName() === '<nolink>' ||
+      $item->external
+    ) {
       return FALSE;
     }
     if (!$request = $this->requestStack->getCurrentRequest()) {
@@ -191,13 +195,6 @@ final class ExternalMenuTreeBuilder {
     }
     $currentPath = parse_url($request->getUri(), PHP_URL_PATH);
     $linkPath = parse_url($item->url->getUri(), PHP_URL_PATH);
-
-    // Subdomain cannot be in active trail.
-    $host = parse_url($item->url->getUri(), PHP_URL_HOST);
-    $host = str_replace('www.', '', $host);
-    if (explode('.', $host)[0] != 'hel') {
-      return FALSE;
-    }
 
     // We don't care about the domain when comparing URLs because the
     // site might be served from multiple different domains.

--- a/src/ExternalMenuTreeBuilder.php
+++ b/src/ExternalMenuTreeBuilder.php
@@ -195,7 +195,7 @@ final class ExternalMenuTreeBuilder {
     // Subdomain cannot be in active trail.
     $host = parse_url($item->url->getUri(), PHP_URL_HOST);
     $host = str_replace('www.', '', $host);
-    if (explode('.',$host)[0] != 'hel') {
+    if (explode('.', $host)[0] != 'hel') {
       return FALSE;
     }
 

--- a/tests/src/Kernel/ExternalMenuTreeBuilderTest.php
+++ b/tests/src/Kernel/ExternalMenuTreeBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_navigation\Kernel;
 
+use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\helfi_navigation\ExternalMenuTreeBuilder;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
@@ -19,6 +20,16 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class ExternalMenuTreeBuilderTest extends MenuTreeBuilderTestBase {
 
   use ProphecyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container) : void {
+    $container->setParameter('helfi_api_base.internal_domains', [
+      'localhost',
+    ]);
+    parent::register($container);
+  }
 
   /**
    * Constructs a new external menu tree.


### PR DESCRIPTION
Fix bug causing an active trail being visible on Etusivu's frontpage's main navigation. Link to external site should never have active trail.

## What was done
Added a check to make sure active trail is never added to a link pointing to subdomain.

## How to install

- Setup `etusivu` and any `other site`
  - Follow the [local development instructions](https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/blob/main/README.md) in helfi_navigation module's readme

## How to test

Reproduce bug
- `other site`:  Edit an existing link or add new link (pointing helfi subdomain) in main navigation. (for example `https://whatever.hel.fi/en`)
  - This link should cause an active trail to be visible in Etusivu's english frontpage.
- `other site`:  Run drush cron
- `ETUSIVU`: Run drush cr 
- `ETUSIVU`:  Go check front page. If you used the link mentioned previously, change language to english. Now there should be active trail indicator in main navigation.

Fix:
- `ETUSIVU`: Run `composer require drupal/helfi_navigation:dev-UHF-8738_activetrail_subdomain`
- Run `drush cr`
- Check the main navigation again
  - There should not be an active trail

Test the other site as well:
- `other site`: Run `git checkout drupal/helfi_navigation:dev-UHF-8738_activetrail_subdomain`
- `other site`: run `drush cr`
  - Main navigation should work as it worked before.

