### PR TITLE
UHF-9830: mobile menu fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 Navigation module allows aggregation of instance specific main-navigations and sharing menus between Helfi-instances.
 The master repository for all menus is `Etusivu`-instance
 
+## How to use
+
+- Update the helfi_navigation.setting.yml configuration values.
+
 ## Features
 
 - Push instance specific main-navigation to Etusivu-instance.

--- a/config/install/helfi_navigation.settings.yml
+++ b/config/install/helfi_navigation.settings.yml
@@ -1,0 +1,1 @@
+global_navigation_enabled: false

--- a/config/schema/helfi_navigation.schema.yml
+++ b/config/schema/helfi_navigation.schema.yml
@@ -47,3 +47,9 @@ block.settings.external_menu_block:*:
     depth:
       type: integer
       label: 'Maximum number of levels'
+
+helfi_navigation.settings:
+  type: mapping
+  mapping:
+    global_navigation_enabled:
+      type: boolean

--- a/config/schema/helfi_navigation.schema.yml
+++ b/config/schema/helfi_navigation.schema.yml
@@ -49,7 +49,7 @@ block.settings.external_menu_block:*:
       label: 'Maximum number of levels'
 
 helfi_navigation.settings:
-  type: mapping
+  type: config_entity
   mapping:
     global_navigation_enabled:
       type: boolean

--- a/src/ApiManager.php
+++ b/src/ApiManager.php
@@ -207,7 +207,9 @@ class ApiManager {
    */
   public function isManuallyDisabled() : bool {
     $configuration = $this->configFactory->get('helfi_navigation.settings')->getRawData();
-    if (empty($configuration)) return false;
+    if (empty($configuration)) {
+      return FALSE;
+    }
 
     return isset($configuration['global_navigation_enabled']) &&
       !$configuration['global_navigation_enabled'];

--- a/src/ApiManager.php
+++ b/src/ApiManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\helfi_navigation;
 
 use Drupal\Core\Config\ConfigException;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\helfi_api_base\ApiClient\ApiClient;
 use Drupal\helfi_api_base\ApiClient\ApiResponse;
 use Drupal\helfi_api_base\ApiClient\CacheValue;
@@ -40,11 +41,14 @@ class ApiManager {
    *   EnvironmentResolver helper class.
    * @param \Drupal\helfi_navigation\ApiAuthorization $apiAuthorization
    *   The API authorization service.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
    */
   public function __construct(
     #[Autowire(service: 'helfi_navigation.api_client')] private ApiClient $client,
     private readonly EnvironmentResolverInterface $environmentResolver,
     private readonly ApiAuthorization $apiAuthorization,
+    private readonly ConfigFactoryInterface $configFactory,
   ) {
   }
 
@@ -193,6 +197,20 @@ class ApiManager {
    */
   public function getAuthorization() : ?string {
     return $this->apiAuthorization->getAuthorization();
+  }
+
+  /**
+   * Get global menu status from module configuration.
+   *
+   * @return bool
+   *   Is global navigation manually disabled.
+   */
+  public function isManuallyDisabled() : bool {
+    $configuration = $this->configFactory->get('helfi_navigation.settings')->getRawData();
+    if (empty($configuration)) return false;
+
+    return isset($configuration['global_navigation_enabled']) &&
+      !$configuration['global_navigation_enabled'];
   }
 
 }

--- a/src/Plugin/rest/resource/GlobalMobileMenu.php
+++ b/src/Plugin/rest/resource/GlobalMobileMenu.php
@@ -100,7 +100,10 @@ final class GlobalMobileMenu extends ResourceBase {
     // "global navigation" to show their own main menu in mobile
     // navigation, namely Rekry.
     // @see https://helsinkisolutionoffice.atlassian.net/browse/UHF-7607
-    if ($this->apiManager->hasAuthorization()) {
+    if (
+      !$this->apiManager->isManuallyDisabled() &&
+      $this->apiManager->hasAuthorization()
+    ) {
       return $this->toResourceResponse(
         $this->normalizeResponseData($apiResponse->data)
       );

--- a/tests/src/Functional/MenuBlockTest.php
+++ b/tests/src/Functional/MenuBlockTest.php
@@ -61,7 +61,7 @@ class MenuBlockTest extends BrowserTestBase {
       ])->save();
 
     $this->config('helfi_navigation.settings')
-      ->set(['global_navigation_enabled' => TRUE])
+      ->set('global_navigation_enabled', TRUE)
       ->save();
 
     NodeType::create([

--- a/tests/src/Functional/MenuBlockTest.php
+++ b/tests/src/Functional/MenuBlockTest.php
@@ -60,6 +60,10 @@ class MenuBlockTest extends BrowserTestBase {
         'es' => 'es',
       ])->save();
 
+    $this->config('helfi_navigation.settings')
+      ->set(['global_navigation_enabled' => TRUE])
+      ->save();
+
     NodeType::create([
       'type' => 'page',
     ])->save();

--- a/tests/src/Unit/ApiManagerTest.php
+++ b/tests/src/Unit/ApiManagerTest.php
@@ -99,7 +99,7 @@ class ApiManagerTest extends UnitTestCase {
     }
 
     if (!$environmentResolver) {
-      $environmentResolver = new EnvironmentResolver('', $this->getConfigFactoryStub([
+      $environmentResolver = new EnvironmentResolver($this->getConfigFactoryStub([
         'helfi_api_base.environment_resolver.settings' => $this->environmentResolverConfiguration,
       ]));
     }
@@ -135,7 +135,7 @@ class ApiManagerTest extends UnitTestCase {
   ) : ApiManager {
 
     if (!$environmentResolver) {
-      $environmentResolver = new EnvironmentResolver('', $this->getConfigFactoryStub([
+      $environmentResolver = new EnvironmentResolver($this->getConfigFactoryStub([
         'helfi_api_base.environment_resolver.settings' => $this->environmentResolverConfiguration,
       ]));
     }
@@ -148,6 +148,9 @@ class ApiManagerTest extends UnitTestCase {
           new AuthorizationToken(ApiAuthorization::VAULT_MANAGER_KEY, $apiKey),
         ] : []),
       ),
+      $this->getConfigFactoryStub([
+        'helfi_api_base.environment_resolver.settings' => $this->environmentResolverConfiguration,
+      ])
     );
   }
 


### PR DESCRIPTION
# [UHF-9830](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9830)
Rekry mobile menu

## What was done
- Read module specific configuration if the global navigation is enabled.

## How to install

* Make sure your instance is up and running on latest dev branch.
  * `git pull origin dev`
  * `make fresh`
* Update the module
  * `composer require drupal/helfi_navigation:dev-UHF-9830`
* Run `make drush-cr`

## How to test
Read the original PR

* [ ] Check that this feature works
* [ ] Check that code follows our standards


## Other PRs


[UHF-9675]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[UHF-9830]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ