### PR TITLE
UHF-10559: Fixed service name

### DIFF
--- a/src/Plugin/QueueWorker/MenuQueue.php
+++ b/src/Plugin/QueueWorker/MenuQueue.php
@@ -41,7 +41,7 @@ final class MenuQueue extends QueueWorkerBase implements ContainerFactoryPluginI
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : self {
     $instance = new self($configuration, $plugin_id, $plugin_definition);
     $instance->mainMenuManager = $container->get(MainMenuManager::class);
-    $instance->cacheTagInvalidator = $container->get('helfi_api_base.cache_tag_invalidator');
+    $instance->cacheTagInvalidator = $container->get(CacheTagInvalidatorInterface::class);
     return $instance;
   }
 

--- a/tests/src/Unit/ApiManagerTest.php
+++ b/tests/src/Unit/ApiManagerTest.php
@@ -54,7 +54,7 @@ class ApiManagerTest extends UnitTestCase {
   protected function setUp() : void {
     parent::setUp();
 
-    $this->cache = new MemoryBackend();
+    $this->cache = new MemoryBackend($this->prophesize(TimeInterface::class)->reveal());
     $this->environmentResolverConfiguration = [
       EnvironmentResolver::PROJECT_NAME_KEY => Project::ASUMINEN,
       EnvironmentResolver::ENVIRONMENT_NAME_KEY => 'local',

--- a/tests/src/Unit/Plugin/QueueWorker/MenuQueueTest.php
+++ b/tests/src/Unit/Plugin/QueueWorker/MenuQueueTest.php
@@ -39,7 +39,7 @@ class MenuQueueTest extends UnitTestCase {
     $pubSubManager = $this->prophesize(PubSubManagerInterface::class);
     $pubSubManager->sendMessage(Argument::any())->willReturn($pubSubManager->reveal());
     $cacheTagInvalidator = new CacheTagInvalidator($pubSubManager->reveal());
-    $container->set('helfi_api_base.cache_tag_invalidator', $cacheTagInvalidator);
+    $container->set(CacheTagInvalidatorInterface::class, $cacheTagInvalidator);
     return MenuQueue::create($container, [], '', []);
   }
 
@@ -84,7 +84,7 @@ class MenuQueueTest extends UnitTestCase {
     ])
       ->shouldBeCalled();
 
-    $container->set('helfi_api_base.cache_tag_invalidator', $cacheTagInvalidator->reveal());
+    $container->set(CacheTagInvalidatorInterface::class, $cacheTagInvalidator->reveal());
     $sut = MenuQueue::create($container, [], '', []);
     $sut->processItem(['menu' => 'main', 'language' => 'fi']);
   }


### PR DESCRIPTION
## How to install

- `composer require drupal/helfi_navigation:dev-UHF-10559`
- `drush cr`

## How to test
* [ ] Run `drush php-eval "_helfi_navigation_queue_item('main', 'fi', 'update');"`
* [ ] Run `drush cron`
* [ ] Make sure no `You have requested a non-existent service "helfi_api_base.cache_tag_invalidator".` error is thrown