### PR TITLE
UHF-10157: Filter untranslated menulinks from fallback trail

### DIFF
--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -129,6 +129,11 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
       /** @var \Drupal\Core\Menu\MenuLinkInterface $link */
       $link = $this->menuLinkManager->createInstance($id);
 
+      // Filter untranslated links to remove non-canonical links.
+      if (!$link->getEntity()->hasTranslation($langcode)) {
+        continue;
+      }
+
       $parentLinks[] = [
         'title' => $link->getTitle(),
         'url' => $link->getUrlObject(),

--- a/src/Plugin/Block/MobileMenuFallbackBlock.php
+++ b/src/Plugin/Block/MobileMenuFallbackBlock.php
@@ -126,7 +126,7 @@ final class MobileMenuFallbackBlock extends MenuBlockBase {
       if (!$this->menuLinkManager->hasDefinition($id)) {
         continue;
       }
-      /** @var \Drupal\Core\Menu\MenuLinkInterface $link */
+      /** @var \Drupal\menu_link_content\Plugin\Menu\MenuLinkContent $link */
       $link = $this->menuLinkManager->createInstance($id);
 
       // Filter untranslated links to remove non-canonical links.


### PR DESCRIPTION
Jira: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10157

**What was done?**

Added check to filter out untranslated menu links from the mobile menu fallback's trail.
Untranslated links were already filtered from the menu tree but the breadcrumb isn't run through the manipulator function.

**How to test?**

Get started:
* Start up [Strategia](https://github.com/City-of-Helsinki/drupal-helfi-strategia/) instance
* Run `make fresh`

View the problem on the current version:
* Go to https://helfi-strategia.docker.so/sv/beslutsfattande-och-forvaltning/stadens-organisation/sektorer/social-halsovards-och-raddningssektorn/laroanstaltssamarbete **with JS disabled**
* Open up the hamburger menu from the top-right corner. You should see a finnish link in  the breadcrumb

Untranslated links cause SEO problems that SiteImprove reports.

To apply the fix:
* Run `composer require drupal/helfi_navigation:dev-UHF-10157` to get this feature
* Repeat these steps:
    * Go to https://helfi-strategia.docker.so/sv/beslutsfattande-och-forvaltning/stadens-organisation/sektorer/social-halsovards-och-raddningssektorn/laroanstaltssamarbete **with JS disabled**
    * Open up the hamburger menu from the top-right corner.

The finnish link should be filtered out and a previous parent link showed in it's place. This is consistent with how the breadcrumb works on desktop.