### PR TITLE
UHF-11652: Never add content_translation_status field to forms that cannot be added to menus

### DIFF
--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -182,6 +182,11 @@ function helfi_navigation_form_node_form_alter(
   FormStateInterface $form_state,
   $form_id,
 ) : void {
+  // Skip if node cannot be added to navigation.
+  if (!isset($form['menu'])) {
+    return;
+  }
+
   assert($form_state->getFormObject() instanceof EntityFormInterface);
   /** @var \Drupal\node\NodeInterface $node */
   $node = $form_state->getFormObject()->getEntity();


### PR DESCRIPTION
## How to install

- Setup KASKO using the `UHF-11652` branch
- Start any other instance
- Run `composer require drupal/helfi_navigation:dev-UHF-11652`
- Run `drush cr`

## How to test

* [ ] Read the [original issue](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11652)  and make sure you cannot reproduce this issue on KASKO
* [ ] Make sure you can still edit/add links to navigation on other instances

## Other PRs

- https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/879

