### PR TITLE
UHF-11867 Menu item queue

### DIFF
--- a/helfi_navigation.module
+++ b/helfi_navigation.module
@@ -13,7 +13,6 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Utility\Error;
-use Drupal\helfi_navigation\ApiAuthorization;
 use Drupal\helfi_navigation\ApiManager;
 use Drupal\menu_link_content\Entity\MenuLinkContent;
 use Drupal\menu_link_content\MenuLinkContentInterface;
@@ -125,9 +124,6 @@ function helfi_navigation_menu_link_content_delete(MenuLinkContentInterface $ent
  * Create menu update queue item.
  */
 function _helfi_navigation_queue_item(string $menuName, string $langcode, string $action) : void {
-  if (!Drupal::service(ApiAuthorization::class)->getAuthorization()) {
-    return;
-  }
   $queue = Drupal::queue('helfi_navigation_menu_queue');
 
   static $items = [];

--- a/tests/src/Kernel/MenuSyncTest.php
+++ b/tests/src/Kernel/MenuSyncTest.php
@@ -43,16 +43,6 @@ class MenuSyncTest extends KernelTestBase {
   }
 
   /**
-   * Make sure nothing gets queued when api key is not set.
-   */
-  public function testQueueNoApiKey() : void {
-    $queue = $this->getQueue();
-
-    _helfi_navigation_queue_item('main', 'fi', 'insert');
-    $this->assertEquals(0, $queue->numberOfItems());
-  }
-
-  /**
    * Make sure items are queued only once.
    */
   public function testQueue() : void {


### PR DESCRIPTION
# What was done

- Removed API authorization check from menu item queue to let the "Etusivu" -instance update the header top and footer global menus.
- Removed the test for checking the API key