### PR TITLE
UHF-12734

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -137,7 +137,7 @@ parameters:
 
 		-
 			message: "#^Access to an undefined property object\\:\\:\\$url\\.$#"
-			count: 4
+			count: 5
 			path: src/ExternalMenuTreeBuilder.php
 
 		-

--- a/src/ExternalMenuTreeBuilder.php
+++ b/src/ExternalMenuTreeBuilder.php
@@ -140,7 +140,16 @@ final class ExternalMenuTreeBuilder implements ExternalMenuTreeBuilderInterface 
     ];
 
     $item->link = $item->url;
-    $item->url = !empty($item->url) ? UrlHelper::parse($item->url) : new Url('<nolink>');
+
+    // #UHF-12734 mega menu would have wrong url on current page's link.
+    if (Url::fromRoute('<front>')->toString() === $item->link) {
+      // Cannot use UrlHelper for the current site's frontpage url since
+      // it would change the url from /fi/asuminen to /fi/asuminen/asuminen.
+      $item->url = Url::fromRoute('<front>');
+    } else {
+      $item->url = !empty($item->url) ? UrlHelper::parse($item->url) : new Url('<nolink>');
+    }
+
     $item->external = $this->domainResolver->isExternal($item->url);
 
     if (isset($item->weight)) {

--- a/src/ExternalMenuTreeBuilder.php
+++ b/src/ExternalMenuTreeBuilder.php
@@ -140,16 +140,7 @@ final class ExternalMenuTreeBuilder implements ExternalMenuTreeBuilderInterface 
     ];
 
     $item->link = $item->url;
-
-    // #UHF-12734 mega menu would have wrong url on current page's link.
-    if (Url::fromRoute('<front>')->toString() === $item->link) {
-      // Cannot use UrlHelper for the current site's frontpage url since
-      // it would change the url from /fi/asuminen to /fi/asuminen/asuminen.
-      $item->url = Url::fromRoute('<front>');
-    } else {
-      $item->url = !empty($item->url) ? UrlHelper::parse($item->url) : new Url('<nolink>');
-    }
-
+    $item->url = $this->createUrl($item->url);
     $item->external = $this->domainResolver->isExternal($item->url);
 
     if (isset($item->weight)) {
@@ -207,6 +198,32 @@ final class ExternalMenuTreeBuilder implements ExternalMenuTreeBuilderInterface 
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * Create url-object for given url.
+   *
+   * @param string|null $url
+   *   The url.
+   *
+   * @return Url
+   *   The url object.
+   */
+  private function createUrl(?string $url): Url {
+    if (!$url) {
+      return new Url('<nolink>');
+    }
+
+    static $frontPage = NULL;
+    if (!$frontPage) {
+      $frontPage = new Url('<front>');
+    }
+
+    if ($url === $frontPage->toString()) {
+      return $frontPage;
+    }
+
+    return UrlHelper::parse($url);
   }
 
 }

--- a/src/ExternalMenuTreeBuilder.php
+++ b/src/ExternalMenuTreeBuilder.php
@@ -206,7 +206,7 @@ final class ExternalMenuTreeBuilder implements ExternalMenuTreeBuilderInterface 
    * @param string|null $url
    *   The url.
    *
-   * @return Url
+   * @return \Drupal\Core\Url
    *   The url object.
    */
   private function createUrl(?string $url): Url {


### PR DESCRIPTION
# [UHF-12734](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12734)

## What was done
On mega menu, the currently active site would have /fi/{sitename}/{sitename} in it's url.



## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Navigation module
  * `composer require drupal/helfi_navigation:dev-UHF-12734`
* Update the hdbt
  *  `composer require drupal/hdbt:dev-UHF-12734`
* Run code updates
  * `composer install`
  * `make drush-updb drush-locale-update drush-cr`

## How to test
- Go to any page
- Check the megamenu
The currently active instances url does not have duplicated sitename in it.
- Check the language swiched on
  - instances front page: no double site name in url
  - Test 404 page
  - Test page with only 1 translation 


[UHF-12734]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ