### PR TITLE
UHF-12754: Updating api manager to use test environment as fallback for etusivu

### DIFF
--- a/src/ApiManager.php
+++ b/src/ApiManager.php
@@ -10,6 +10,7 @@ use Drupal\helfi_api_base\ApiClient\ApiClient;
 use Drupal\helfi_api_base\ApiClient\ApiResponse;
 use Drupal\helfi_api_base\ApiClient\CacheValue;
 use Drupal\helfi_api_base\Cache\CacheKeyTrait;
+use Drupal\helfi_api_base\Environment\EnvironmentEnum;
 use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
 use Drupal\helfi_api_base\Environment\Project;
 use GuzzleHttp\Exception\GuzzleException;
@@ -183,8 +184,14 @@ class ApiManager {
       ->getActiveEnvironment();
     $activeEnvironmentName = $activeEnvironment
       ->getEnvironmentName();
-    $env = $this->environmentResolver
-      ->getEnvironment(Project::ETUSIVU, $activeEnvironmentName);
+
+    // Get matching environment for etusivu project. Use test environment as
+    // fallback.
+    $etusivu_project = $this->environmentResolver->getProject(Project::ETUSIVU);
+    if (!$etusivu_project->hasEnvironment($activeEnvironmentName)) {
+      $activeEnvironmentName = EnvironmentEnum::Test->value;
+    }
+    $env = $etusivu_project->getEnvironment($activeEnvironmentName);
 
     return match ($type) {
       'canonical' => $env->getUrl($langcode),

--- a/src/ApiManager.php
+++ b/src/ApiManager.php
@@ -187,11 +187,11 @@ class ApiManager {
 
     // Get matching environment for etusivu project. Use test environment as
     // fallback.
-    $etusivu_project = $this->environmentResolver->getProject(Project::ETUSIVU);
-    if (!$etusivu_project->hasEnvironment($activeEnvironmentName)) {
+    $etusivuProject = $this->environmentResolver->getProject(Project::ETUSIVU);
+    if (!$etusivuProject->hasEnvironment($activeEnvironmentName)) {
       $activeEnvironmentName = EnvironmentEnum::Test->value;
     }
-    $env = $etusivu_project->getEnvironment($activeEnvironmentName);
+    $env = $etusivuProject->getEnvironment($activeEnvironmentName);
 
     return match ($type) {
       'canonical' => $env->getUrl($langcode),

--- a/tests/src/Unit/ApiManagerTest.php
+++ b/tests/src/Unit/ApiManagerTest.php
@@ -115,6 +115,8 @@ class ApiManagerTest extends UnitTestCase {
    *   The environment resolver.
    * @param string|null $apiKey
    *   The api key.
+   * @param \Drupal\helfi_api_base\Environment\EnvironmentEnum|null $environment
+   *   The environment.
    *
    * @return \Drupal\helfi_navigation\ApiManager
    *   The api manager instance.
@@ -123,10 +125,11 @@ class ApiManagerTest extends UnitTestCase {
     ApiClient $client,
     ?EnvironmentResolverInterface $environmentResolver = NULL,
     ?string $apiKey = '123',
+    ?EnvironmentEnum $environment = EnvironmentEnum::Local,
   ) : ApiManager {
 
     if (!$environmentResolver) {
-      $environmentResolver = $this->getEnvironmentResolver(Project::ASUMINEN, EnvironmentEnum::Local);
+      $environmentResolver = $this->getEnvironmentResolver(Project::ASUMINEN, $environment);
     }
     return new ApiManager(
       $client,
@@ -140,7 +143,7 @@ class ApiManagerTest extends UnitTestCase {
       $this->getConfigFactoryStub([
         'helfi_api_base.environment_resolver.settings' => [
           EnvironmentResolver::PROJECT_NAME_KEY => Project::ASUMINEN,
-          EnvironmentResolver::ENVIRONMENT_NAME_KEY => EnvironmentEnum::Local->value,
+          EnvironmentResolver::ENVIRONMENT_NAME_KEY => $environment->value,
         ],
       ])
     );
@@ -275,6 +278,22 @@ class ApiManagerTest extends UnitTestCase {
       $this->assertInstanceOf(\stdClass::class, $response->data);
       $this->assertEquals(1, $response->data->value);
     }
+  }
+
+  /**
+   * Tests getUrl() with fallback environment.
+   *
+   * @covers ::getUrl
+   */
+  public function testGetUrlWithFallbackEnvironment() : void {
+    $sut = $this->getSut(
+      client: $this->getApiClientMock($this->createMockHttpClient([])),
+      environmentResolver: $this->getEnvironmentResolver(Project::GRANTS, EnvironmentEnum::Dev),
+      environment: EnvironmentEnum::Dev,
+    );
+
+    $url = $sut->getUrl('canonical', 'fi');
+    $this->assertEquals('https://www.test.hel.ninja/fi', $url);
   }
 
 }


### PR DESCRIPTION
# [UHF-12754](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12754)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* This is needed for avustusasiointi dev environment.

## How to install

_Any instance should do, to make sure this doesn't break anything._

* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Switch to feature branch versions of `helfi_navigation`-module
  * `composer require drupal/helfi_navigation:dev-UHF-12754_p2`
* Run code updates
  * `composer install`
  * `make drush-deploy drush-locale-update drush-cr`

## How to test

* [ ] Go to your instance frontpage; header and footer menu elements should work normally, in both desktop and mobile layouts.

<!-- 
Check list for the developer

Privacy  
- Do the changes you made have an impact on privacy? If you are unsure, please check the checklist at: https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/9930473479/Tietosuojan+tarkistuslista+kehitt+jille

Documentation
- Check the documentation exists and is up to date. Add link if the documentation is not included in the PR.

Translations
- Make sure all necessary translations have been added.
-->


[UHF-12754]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ