### PR TITLE
UHF-13438: D11.4 fix

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,15 @@ parameters:
 			path: helfi_navigation.install
 
 		-
+			message: """
+				#^Call to deprecated function menu_ui_get_menu_link_defaults\\(\\)\\:
+				in drupal\\:11\\.4\\.0 and is removed from drupal\\:13\\.0\\.0\\. Use
+				  \\\\Drupal\\\\menu_ui\\\\MenuUiUtility\\:\\:getMenuLinkDefaults\\(\\) instead\\.$#
+			"""
+			count: 1
+			path: helfi_navigation.module
+
+		-
 			message: "#^Function helfi_navigation_entity_base_field_info\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: helfi_navigation.module
@@ -226,12 +235,12 @@ parameters:
 			path: src/Menu/MenuTreeBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$entity_type_id of method Drupal\\\\Core\\\\Entity\\\\EntityTypeManagerInterface\\:\\:getStorage\\(\\) expects string, int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$entity_type_id of method Drupal\\\\Core\\\\Entity\\\\EntityTypeManagerInterface\\:\\:getStorage\\(\\) expects string, int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string given\\.$#"
 			count: 1
 			path: src/Menu/MenuTreeBuilder.php
 
 		-
-			message: "#^Parameter \\#1 \\$plugin_id of method Drupal\\\\Component\\\\Plugin\\\\Discovery\\\\DiscoveryInterface\\:\\:hasDefinition\\(\\) expects string, int\\|string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$plugin_id of method Drupal\\\\Component\\\\Plugin\\\\Discovery\\\\DiscoveryInterface\\:\\:hasDefinition\\(\\) expects string, int\\<min, \\-1\\>\\|int\\<1, max\\>\\|string given\\.$#"
 			count: 1
 			path: src/Menu/MenuTreeBuilder.php
 
@@ -274,6 +283,11 @@ parameters:
 			message: "#^Method Drupal\\\\helfi_navigation\\\\Plugin\\\\DebugDataItem\\\\ApiAvailability\\:\\:create\\(\\) has parameter \\$configuration with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Plugin/DebugDataItem/ApiAvailability.php
+
+		-
+			message: "#^Cannot access offset 'admin_label' on array\\|Drupal\\\\Component\\\\Plugin\\\\Definition\\\\PluginDefinitionInterface\\.$#"
+			count: 1
+			path: src/Plugin/Derivative/ExternalMenuBlock.php
 
 		-
 			message: "#^Method Drupal\\\\helfi_navigation\\\\Plugin\\\\Derivative\\\\ExternalMenuBlock\\:\\:getDerivativeDefinitions\\(\\) has parameter \\$base_plugin_definition with no value type specified in iterable type array\\.$#"

--- a/src/Menu/MenuTreeBuilder.php
+++ b/src/Menu/MenuTreeBuilder.php
@@ -302,7 +302,7 @@ final class MenuTreeBuilder {
     $routeParameters = $element->link->getRouteParameters();
     $entityType = key($routeParameters);
 
-    if (!$this->entityTypeManager->hasDefinition($entityType)) {
+    if (!$entityType || !$this->entityTypeManager->hasDefinition($entityType)) {
       return;
     }
     $storage = $this->entityTypeManager


### PR DESCRIPTION
# [UHF-13438](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13438)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Fixed an error which causes an Etusivu test to fail: `Deprecated function: str_contains(): Passing null to parameter #1 () of type string is deprecated.`

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running on latest dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update the Helfi Navigation module
  * `composer require drupal/helfi_navigation:dev-UHF-13438`
* Run code updates
  * `composer install`
  * `make drush-updb drush-locale-update drush-cr`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* [ ] Run etusivun tests and check that the tests pass.
* [ ] Check that the code follows our standards


[UHF-13438]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ